### PR TITLE
Fix array expansion

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -26,7 +26,7 @@ dev_packages=(
    dotnet6
 )
 
-sudo apt-get install -y "${dev_packages[*]}"
+sudo apt-get install -y "${dev_packages[@]}"
 
 
 if [[ "$installGUIApps" != "n" ]]; then


### PR DESCRIPTION
"${var[*]}" expands to a single string of "item1 item2 item3 item4 with space", which isn't what we want. We want it expanded to "item1" "item2" "item3" "item4 with space". This fixes the install command so it actually finds the packages.